### PR TITLE
Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build-dir/
+/.flatpak-builder/

--- a/0001-switch-to-uint_t.patch
+++ b/0001-switch-to-uint_t.patch
@@ -1,0 +1,41 @@
+From f5be83735cc83488263c857c82d203f3575063af Mon Sep 17 00:00:00 2001
+From: bbhtt <62639087+bbhtt@users.noreply.github.com>
+Date: Fri, 20 May 2022 22:16:47 +0530
+Subject: [PATCH] Switch to uint_t else build fails
+
+---
+ outputs/tiff.cpp | 2 +-
+ outputs/tiff.hpp | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/outputs/tiff.cpp b/outputs/tiff.cpp
+index c3b8cd1..21e7b74 100644
+--- a/outputs/tiff.cpp
++++ b/outputs/tiff.cpp
+@@ -273,7 +273,7 @@ tiff_odevice::boi (const context& ctx)
+ 
+   TIFFSetField (tiff_, TIFFTAG_SAMPLESPERPIXEL, ctx.comps ());
+ 
+-  uint16 pm = 0;                // uint16 is courtesy of tiffio.h
++  uint16_t pm = 0;                // uint16 is courtesy of tiffio.h
+   if (8 == ctx.depth())
+     {
+       if (3 == ctx.comps())
+diff --git a/outputs/tiff.hpp b/outputs/tiff.hpp
+index 8402174..8fcd30f 100644
+--- a/outputs/tiff.hpp
++++ b/outputs/tiff.hpp
+@@ -53,8 +53,8 @@ protected:
+ 
+ private:
+   TIFF   *tiff_;
+-  uint32  page_;
+-  uint32  row_;
++  uint32_t  page_;
++  uint32_t  row_;
+ 
+   boost::scoped_array< octet > partial_line_;
+   streamsize                   partial_size_;
+-- 
+2.36.1
+

--- a/com.github.utsushi.Utsushi.json
+++ b/com.github.utsushi.Utsushi.json
@@ -2,7 +2,7 @@
     "app-id" : "com.github.utsushi.Utsushi",
     "command": "utsushi",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.38",
+    "runtime-version" : "42",
     "sdk" : "org.gnome.Sdk",
     "finish-args" : [
 		"--socket=x11",
@@ -11,11 +11,15 @@
 		"--share=network"
     ],
     "cleanup": [
-		"/include",
-		"/lib/pkgconfig",
-		"/share/devhelp",
-		"/share/doc",
-		"/share/man"
+        "*.a",
+        "*.la",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/aclocal",
+        "/share/pkgconfig",
+        "/share/devhelp",
+        "/share/doc",
+        "/share/man"
     ],
     "modules": [
 		{
@@ -23,8 +27,8 @@
             "sources": [
 		{
                     "type": "archive",
-                    "url": "http://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.bz2",
-                    "sha256": "7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332"
+                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2",
+                    "sha256": "475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39"
 		}
             ],
             "buildsystem": "simple",
@@ -38,23 +42,33 @@
 		"shared-modules/libusb/libusb.json",
 		"shared-modules/gtk2/gtk2.json",
         {
-            "name": "sigc++-2",
+            "name": "mm-common",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.3.tar.xz",
-                    "sha256": "0b68dfc6313c6cc90ac989c6d722a1bf0585ad13846e79746aa87cb265904786"
+                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.4.tar.xz",
+                    "sha256": "e954c09b4309a7ef93e13b69260acdc5738c907477eb381b78bb1e414ee6dbd8"
                 }
+            ],
+            "cleanup": [
+                "/share/mm-common",
+                "/bin/mm-common*"
             ]
         },
         {
-            "name": "cairomm",
+            "name": "sigc++",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/cairomm/1.12/cairomm-1.12.0.tar.xz",
-                    "sha256": "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6"
+                    "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz",
+                    "sha256": "235a40bec7346c7b82b6a8caae0456353dc06e71f14bc414bcc858af1838719a"
                 }
+            ],
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "cleanup": [
+                "/lib/sigc++-2.0"
             ]
         },
         {
@@ -62,9 +76,35 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.64/glibmm-2.64.2.tar.xz",
-                    "sha256": "a75282e58d556d9b2bb44262b6f5fb76c824ac46a25a06f527108bec86b8d4ec"
+                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.3.tar.xz",
+                    "sha256": "afb96202491485d3f44102d98219a172da2d3f9eb78fce3cfb92559ba496e499"
                 }
+            ],
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-documentation=false",
+                "-Dbuild-examples=false"
+            ],
+            "cleanup": [
+                "/lib/glibmm-2.4",
+                "/lib/giomm-2.4",
+                "/lib/libglibmm_generate_extra_defs*"
+            ]
+        },
+        {
+            "name": "cairomm",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://gitlab.freedesktop.org/cairo/cairomm/-/archive/1.14.3/cairomm-1.14.3.tar.gz",
+                    "sha256": "7dab16c5698acb284f178048337465b463fbed01c49e10bfe48acb0a852d873e"
+                }
+            ],
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "cleanup": [
+                "/lib/cairomm-1.0"
             ]
         },
         {
@@ -72,9 +112,16 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.42/pangomm-2.42.1.tar.xz",
-                    "sha256": "14bf04939930870d5cfa96860ed953ad2ce07c3fd8713add4a1bfe585589f40f"
+                    "url": "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.2.tar.xz",
+                    "sha256": "57442ab4dc043877bfe3839915731ab2d693fc6634a71614422fb530c9eaa6f4"
                 }
+            ],
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-documentation=false"
+            ],
+            "cleanup": [
+                "/lib/pangomm-1.4"
             ]
         },
         {
@@ -82,9 +129,16 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/atkmm/2.28/atkmm-2.28.0.tar.xz",
-                    "sha256": "4c4cfc917fd42d3879ce997b463428d6982affa0fb660cafcc0bc2d9afcedd3a"
+                    "url": "https://download.gnome.org/sources/atkmm/2.28/atkmm-2.28.2.tar.xz",
+                    "sha256": "a0bb49765ceccc293ab2c6735ba100431807d384ffa14c2ebd30e07993fd2fa4"
                 }
+            ],
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-documentation=false"
+            ],
+            "cleanup": [
+                "/lib/atkmm-1.6"
             ]
         },
         {
@@ -92,9 +146,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/2.24/gtkmm-2.24.5.tar.xz",
+                    "url": "https://download.gnome.org/sources/gtkmm/2.24/gtkmm-2.24.5.tar.xz",
                     "sha256": "0680a53b7bf90b4e4bf444d1d89e6df41c777e0bacc96e9c09fc4dd2f5fe6b72"
                 }
+            ],
+            "cleanup": [
+                "/lib/gdkmm-2.0",
+                "/lib/gtkmm-2.0"
             ]
         },
 		{
@@ -108,8 +166,8 @@
 			"sources": [
 				{
 					"type": "archive",
-					"url": "https://downloads.sourceforge.net/graphicsmagick/GraphicsMagick-1.3.35.tar.xz",
-					"sha256": "188a8d6108fea87a0208723e8d206ec1d4d7299022be8ce5d0a9720509250250"
+					"url": "https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/1.3.38/GraphicsMagick-1.3.38.tar.xz",
+					"sha256": "d60cd9db59351d2b9cb19beb443170acaa28f073d13d258f67b3627635e32675"
 				}
 			]
 		},
@@ -127,7 +185,11 @@
 				{
 					"type": "git",
 					"url": "https://gitlab.com/utsushi/utsushi.git",
-					"commit": "ab7063358c9819dd37129c6ba58da1009302bdd7"
+					"commit": "839d06a5a80b353cb604eb9f7d352a1648ab1fdf"
+				},
+				{
+					"type":"patch",
+					"path":"0001-switch-to-uint_t.patch"
 				},
 				{
 					"type": "file",


### PR DESCRIPTION
See individual commits for details.

gtkmm and deps uses meson now (except gtkmm which doesn't support it at the current version it seems). This had to be done else build was failing due to issues like https://gitlab.gnome.org/GNOME/glibmm/-/issues/81

I'm going to make an issue to upstream about the patch, without that the build was failing due to `Wno-error=deprecated-declarations uint is deprecated`. But upstream isn't very active so let's see.  

I opened https://gitlab.com/utsushi/utsushi/-/issues/111

This built fine locally, needs testing though.

Also, updates Utsushi to the latest git commit which is from 1 year ago.